### PR TITLE
feat: expose sanpou-site sitemap to crawlers via robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://mdaisuke.net/sitemap.xml
+Sitemap: https://mdaisuke.net/sanpou-site/sitemap-index.xml


### PR DESCRIPTION
## Summary

- Adds a static `robots.txt` at the repo root listing **both** sitemaps:
  - `https://mdaisuke.net/sitemap.xml` (portfolio)
  - `https://mdaisuke.net/sanpou-site/sitemap-index.xml` (sanpou sub-site)
- Without this, the `jekyll-sitemap` plugin auto-generates a `robots.txt` that references only `/sitemap.xml`. That sitemap contains zero sanpou URLs, so crawlers have no path to discover the sanpou-site sub-site — it gets effectively no organic search traffic.
- A root-level file with no YAML front matter is copied verbatim by Jekyll, and `jekyll-sitemap` skips its own generation when a `/robots.txt` already exists (`@site.pages << robots unless file_exists?("robots.txt")`).

## Test plan

- [x] Confirmed `jekyll-sitemap` 1.4.0 source skips robots.txt generation when a static `/robots.txt` exists
- [x] `robots.txt` has no front matter → Jekyll treats it as a verbatim static file
- [ ] After merge + deploy: `curl -sL https://mdaisuke.net/robots.txt` shows both `Sitemap:` lines
- [ ] Submit `sanpou-site/sitemap-index.xml` in Google Search Console
- [ ] Within days–weeks: sanpou URLs appear as indexed in GSC Pages report

🤖 Generated with [Claude Code](https://claude.com/claude-code)