### PR TITLE
feat: show excerpt as a visible TL;DR block atop posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,7 +16,7 @@ layout: default
   <!-- 要約(TL;DR): front matter の excerpt を冒頭に可視化。AI抽出器・読者双方に要点を提示 -->
   {% if page.excerpt %}
   <aside
-    class="mb-8 rounded-lg border-l-4 border-primary-link bg-gray-100 px-4 py-3 dark:border-primary-link-dark dark:bg-gray-800"
+    class="mb-8 rounded-lg bg-gray-100 px-4 py-3 dark:bg-gray-800"
   >
     <p
       class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -13,6 +13,22 @@ layout: default
     </h1>
   </header>
 
+  <!-- 要約(TL;DR): front matter の excerpt を冒頭に可視化。AI抽出器・読者双方に要点を提示 -->
+  {% if page.excerpt %}
+  <aside
+    class="mb-8 rounded-lg border-l-4 border-primary-link bg-gray-100 px-4 py-3 dark:border-primary-link-dark dark:bg-gray-800"
+  >
+    <p
+      class="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400"
+    >
+      {% if page.lang == "jp" %}要点{% else %}TL;DR{% endif %}
+    </p>
+    <p class="m-0 text-sm text-gray-700 dark:text-gray-300">
+      {{ page.excerpt | strip_html | strip_newlines }}
+    </p>
+  </aside>
+  {% endif %}
+
   <div class="prose prose-lg w-full max-w-none dark:prose-invert">
     {{ content }}
   </div>


### PR DESCRIPTION
## Summary
- Render each post's front-matter `excerpt` as a styled summary callout above the body, labelled **TL;DR** (EN) / **要点** (JP).
- Surfaces the key point to both readers and AI extractors (Gemini etc.) — the excerpt was previously only in `<meta description>`, never visible on-page.
- Reuses existing excerpt text (all 49 posts already have one), so **no copywriting and low risk**. Gated on `page.excerpt`.

## Test plan
- [x] `jekyll build` passes
- [x] EN posts render "TL;DR", JP posts render "要点", with the correct excerpt text
- [x] Block gated on `page.excerpt` (renders only on posts)
- [ ] Visual/styling check on deploy preview (Tailwind JIT compiles the new utilities on the real build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)