### PR TITLE
feat: per-post head metadata — BlogPosting JSON-LD + per-page OpenGraph

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -32,16 +32,36 @@
   />
 
   <!-- open graph -->
-  <meta property="og:title" content="Daisuke (Daisuke Miyazaki)" />
-  <meta property="og:type" content="website" />
-  <meta property="og:image" content="https://mdaisuke.net/pics/avatar.jpg" />
+  {% capture og_url %}{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}{% endcapture %}
+  <meta
+    property="og:title"
+    content="{% if page.title %}{{ page.title | escape }}{% else %}Daisuke (Daisuke Miyazaki){% endif %}"
+  />
+  <meta
+    property="og:type"
+    content="{% if page.layout == 'post' %}article{% else %}website{% endif %}"
+  />
+  <meta
+    property="og:image"
+    content="{% if page.thumbnail %}{{ page.thumbnail | prepend: site.url }}{% else %}https://mdaisuke.net/pics/avatar.jpg{% endif %}"
+  />
   <meta
     property="og:description"
     content="{% if page.description %}{{ page.description | strip_html | strip_newlines | truncate: 160 }}{% elsif page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}Daisuke is an engineer based in Tokyo. This is his personal website.{% endif %}"
   />
-  <meta property="og:url" content="https://mdaisuke.net" />
-  <meta property="og:locale" content="en_US" />
+  <meta property="og:url" content="{{ og_url }}" />
+  <meta
+    property="og:locale"
+    content="{% if page.lang == 'jp' %}ja_JP{% else %}en_US{% endif %}"
+  />
   <meta property="og:site_name" content="Daisuke Miyazaki" />
+  {% if page.layout == "post" %}
+  <meta
+    property="article:published_time"
+    content="{{ page.date | date_to_xmlschema }}"
+  />
+  <meta property="article:author" content="Daisuke Miyazaki" />
+  {% endif %}
 
   {% assign posts=site.posts | where:"lang-ref", page.lang-ref | sort: 'lang' %}
   {% if posts.size == 0 %} {% assign posts=site.pages | where:"lang-ref",

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -53,6 +53,28 @@
     href="{{ site.base-url }}{{ post.url }}"
   />
   {% endfor %} {% endif %}
+
+  <!-- structured data: BlogPosting (helps AI/search surfaces parse articles) -->
+  {% if page.layout == "post" %}
+  {% capture _canonical %}{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}{% endcapture %}
+  {% assign _desc = page.description | default: page.excerpt | strip_html | strip_newlines | truncate: 200 %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "mainEntityOfPage": { "@type": "WebPage", "@id": {{ _canonical | jsonify }} },
+    "url": {{ _canonical | jsonify }},
+    "headline": {{ page.title | jsonify }},
+    "description": {{ _desc | jsonify }},
+    "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
+    "dateModified": {{ page.date | date_to_xmlschema | jsonify }},
+    "inLanguage": {% if page.lang == "jp" %}"ja"{% else %}"en"{% endif %},
+    "author": { "@type": "Person", "name": "Daisuke Miyazaki", "url": {{ site.url | jsonify }} },
+    "publisher": { "@type": "Person", "name": "Daisuke Miyazaki", "url": {{ site.url | jsonify }} },
+    "image": {% if page.thumbnail %}{{ page.thumbnail | prepend: site.url | jsonify }}{% else %}"https://mdaisuke.net/pics/avatar.jpg"{% endif %}
+  }
+  </script>
+  {% endif %}
 </head>
 
 <!-- Global site tag (gtag.js) - Google Analytics -->


### PR DESCRIPTION
## Summary
Two related `_includes/head.html` changes so search/AI surfaces (e.g. Gemini) and social cards parse each article correctly.

**1. BlogPosting JSON-LD** (commit `e92119a`)
- Emits `schema.org/BlogPosting` for every `layout: post` page, from existing front matter (title/excerpt/date/lang). `jp`→`ja`; `image` from thumbnail or avatar fallback. Uses `| jsonify` for safe escaping; no Gemfile/plugin changes.

**2. Per-page OpenGraph** (commit `2b9bd69`)
- `og:title/type/url/locale/image` were hardcoded to the homepage, so every article shared the same preview. Now derived per page: title from `page.title`, `type=article` for posts, canonical `url`, `locale` by lang, `image` from thumbnail when set.
- Adds `article:published_time` / `article:author` for posts (aligns with the JSON-LD).

## Test plan
- [x] `jekyll build` passes
- [x] EN/JP posts: valid BlogPosting JSON-LD (correct `inLanguage`, canonical, ISO date)
- [x] Posts: `og:type=article`, per-post `og:title`/`og:url`/`og:locale`, `article:published_time`
- [x] Home: `og:type=website`, default title, no `article:*`, no JSON-LD
- [ ] Visual check on deploy preview / Search Console rich-results test

## Notes
- Pre-existing, out of scope: thumbnail filename `dont delegate understandings.jpeg` contains spaces, so its `og:image` URL does too (same as the existing markdown reference). Renaming the asset is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)